### PR TITLE
Support for async rule creation in Sentry

### DIFF
--- a/sentry/rules_test.go
+++ b/sentry/rules_test.go
@@ -203,7 +203,7 @@ func TestRulesService_Create(t *testing.T) {
 
 }
 
-func TestRulesService_Create_Async_Task(t *testing.T) {
+func TestRulesService_Create_With_Async_Task(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()
 


### PR DESCRIPTION
When creating rules targeting Slack (`SlackNotifyServiceAction`), sometimes Sentry will spawn async task and return a reference (a `UUID`) to it instead of the created rule. This response is a `HTTP 202 Accepted`, so it is interpreted as a success and read into a [`Rule` struct ](https://github.com/jianyuan/go-sentry/blob/main/sentry/rules.go). 

In itself, nothing here causes a crash, since the task will eventually finish with (or without) success. Where it causes a problem is when we try to read back from Sentry the rule with the id set to `""` (since the struct is initialized with the defaults). It crashes with a cryptic message saying ` Error: Could not find rule with ID `, with a blank space next to ID since it is equal to `""`.

This fix will catch the async creation and query the task to check its status and return the created rule when the task finishes with success or return an appropriate error message.